### PR TITLE
Fix breaking rake on windows

### DIFF
--- a/tasks/railroady.rake
+++ b/tasks/railroady.rake
@@ -26,8 +26,10 @@ module RailRoady
     def self.sed
       regex = 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g'
       case RbConfig::CONFIG['host_os']
-      when /linux|cygwin|mingw/
+      when /linux/
         return "sed -r '#{regex}'"
+      when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+        return "sed -r \"#{regex}\""
       when /mac|darwin|bsd/
         return "sed -E '#{regex}'"
       else


### PR DESCRIPTION
On windows the pipe symbol in the regex is interpreted as a pipe which results in an unknown program or command error. In order to fix this, the regex is enclosed in double quotes instead of single quotes.